### PR TITLE
Added config file and template text option

### DIFF
--- a/App.config
+++ b/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/Config.cs
+++ b/Config.cs
@@ -1,0 +1,72 @@
+﻿namespace DSDeaths
+{
+    public class Config
+    {
+        public static readonly string json =
+@"{
+  ""Dark Souls I"": {
+    ""process"": ""DARKSOULS"",
+    ""offsets"": [
+      ""0xF78700"",
+      ""0x5c""
+    ],
+    ""isWow64"": true
+  },
+  ""Dark Souls II"": {
+    ""process"": ""DarkSoulsII"",
+    ""offsets"": [
+      ""0x1150414"",
+      ""0x74"",
+      ""0xB8"",
+      ""0x34"",
+      ""0x4"",
+      ""0x28C"",
+      ""0x100""
+    ],
+    ""isWow64"": true
+  },
+  ""Dark Souls II: Scholar of the First Sin"": {
+    ""process"": ""DarkSoulsII"",
+    ""offsets"": [
+      ""0x16148F0"",
+      ""0xD0"",
+      ""0x490"",
+      ""0x104""
+    ],
+    ""isWow64"": false
+  },
+  ""Dark Souls III"": {
+    ""process"": ""DarkSoulsIII"",
+    ""offsets"": [
+      ""0x47572B8"",
+      ""0x98""
+    ],
+    ""isWow64"": false
+  },
+  ""Dark Souls I: Remastered"": {
+    ""process"": ""DarkSoulsRemastered"",
+    ""offsets"": [
+      ""0x1C8A530"",
+      ""0x98""
+    ],
+    ""isWow64"": false
+  },
+  ""Sekiro"": {
+    ""process"": ""Sekiro"",
+    ""offsets"": [
+      ""0x3D5AAC0"",
+      ""0x90""
+    ],
+    ""isWow64"": false
+  },
+  ""Elden Ring"": {
+    ""process"": ""eldenring"",
+    ""offsets"": [
+      ""0x3C17EE8"",
+      ""0x94""
+    ],
+    ""isWow64"": false
+  }
+}";
+    }
+}

--- a/DSDeaths.csproj
+++ b/DSDeaths.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>DSDeaths</RootNamespace>
     <AssemblyName>DSDeaths</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -57,6 +58,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -65,6 +67,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Config.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Hey I added some new features to the tracker:
1) The tracker will now create a predefined config.json file which can be edited without recompiling the code.
2) The tracker can now differentiate between 32-bit and 64-bit applications by using the "isWow64" switch inside the config.
3) I added the new pointer offsets from #26 for regular ds2 and sotfs ds2.
4) The tracker will create a template.txt file which can be used to display a custom text. For example: "My Deaths: $deaths :(". $deaths will be replaced with the actual deaths and written into the deaths.txt file.
5) I added timestamps for the console messages.

Should be stable but still needs further testing, sadly I don't own all FromSoftware games.