### PR TITLE
Fix extensive cpu usage when PeekMemory fails

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -66,6 +66,7 @@ namespace DSDeaths {
                 address += offset;
 
                 if (!ReadProcessMemory(handle, (IntPtr)address, buffer, 8, ref discard)) {
+                    Console.WriteLine("Could not read game memory.");
                     return false;
                 }
 
@@ -129,9 +130,8 @@ namespace DSDeaths {
                                 oldValue = value;
                                 Write(value);
                             }
-
-                            Thread.Sleep(500);
                         }
+                        Thread.Sleep(500);
                     }
                 }
 


### PR DESCRIPTION
PR fixes bug, where thread sleep would be skipped when PeekMemory returns false (due to game update, memory access problem, etc), which results in 100% usage of cpu core.
Also added error msg when ReadProcessMemory() fails, so it doesn't go unnoticed.