### PR TITLE
change dir to DSDeaths.exe parent directory on startup

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -97,6 +97,9 @@ namespace DSDeaths {
                 Write(0);
             };
 
+            // put DSDeaths.txt in the same directory as the exe
+            Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
+
             Console.WriteLine("-----------------------------------WARNING-----------------------------------");
             Console.WriteLine(" Does NOT work with Elden Ring if Easy Anti-Cheat (EAC) is running.");
             Console.WriteLine(" Possible risk of BANS by trying to use with EAC enabled.");


### PR DESCRIPTION
apparently if you run DSDeaths by opening the start menu and searching for it from there, the cwd of the process is set to system32, which we (hopefully) don't have write access to.