### PR TITLE
Print deaths to console

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -128,6 +128,7 @@ namespace DSDeaths {
                         if (PeekMemory(handle, baseAddress, !isWow64, offsets, ref value)) {
                             if (value != oldValue) {
                                 oldValue = value;
+                                Console.WriteLine("Deaths: " + value.ToString());
                                 Write(value);
                             }
                         }

--- a/Program.cs
+++ b/Program.cs
@@ -45,7 +45,6 @@ namespace DSDeaths {
         static bool Write(int value) {
             try {
                 File.WriteAllText("DSDeaths.txt", value.ToString());
-                Console.WriteLine("Deaths: " + value.ToString());
             } catch (IOException) {
                 Console.WriteLine("Could not write to DSDeaths.txt.");
                 return false;

--- a/Program.cs
+++ b/Program.cs
@@ -45,6 +45,7 @@ namespace DSDeaths {
         static bool Write(int value) {
             try {
                 File.WriteAllText("DSDeaths.txt", value.ToString());
+                Console.WriteLine("Deaths: " + value.ToString());
             } catch (IOException) {
                 Console.WriteLine("Could not write to DSDeaths.txt.");
                 return false;


### PR DESCRIPTION
If you don't want to open an external software like OBS to display the death count, it shall be displayed in the console